### PR TITLE
Improve `AffineDecomposition`

### DIFF
--- a/examples/basis_analysis.jl
+++ b/examples/basis_analysis.jl
@@ -73,7 +73,7 @@ rbres = assemble(H, grid_train, greedy, dm, edcomp;
 
 # Using this presumably inaccurate surrogate, we compute the magnetization
 
-M = AffineDecomposition([H.terms[3]], μ -> [2 / L])
+M = AffineDecomposition([H.terms[3]], [2 / L])
 m, _ = compress(M, rbres.basis)
 m_reduced = m();
 

--- a/examples/basis_analysis.jl
+++ b/examples/basis_analysis.jl
@@ -31,11 +31,11 @@ function xxz_chain(sites::IndexSet; kwargs...)
         magn_term += "Sz", i
     end
     magn_term += "Sz", length(sites)  # Add last magnetization term
-    coefficient_map = μ -> [1.0, μ[1], -μ[2]]
+    coefficients = μ -> [1.0, μ[1], -μ[2]]
     AffineDecomposition([ApproxMPO(MPO(xy_term, sites), xy_term; kwargs...),
                          ApproxMPO(MPO(zz_term, sites), zz_term; kwargs...),
                          ApproxMPO(MPO(magn_term, sites), magn_term; kwargs...)],
-                        coefficient_map)
+                        coefficients)
 end
 
 L = 12
@@ -75,7 +75,7 @@ rbres = assemble(H, grid_train, greedy, dm, edcomp;
 
 M = AffineDecomposition([H.terms[3]], μ -> [2 / L])
 m, _ = compress(M, rbres.basis)
-m_reduced = m([]);
+m_reduced = m();
 
 # on a finer online grid using the matching online solver
 

--- a/examples/basis_analysis.jl
+++ b/examples/basis_analysis.jl
@@ -174,7 +174,7 @@ rbres_cont = assemble(rbres, H, grid_train, greedy_cont, dm, edcomp);
 # recomputing the magnetization using the continued basis:
 
 m_cont, m_cont_raw = compress(M, rbres_cont.basis)
-m_reduced_cont = m_cont([])
+m_reduced_cont = m_cont()
 
 magn_cont = map(grid_online) do μ
     _, φ_rb = solve(rbres_cont.h_cache.h, rbres_cont.basis.metric, μ, fulldiag)
@@ -208,7 +208,7 @@ h_cache_trunc = truncate(rbres_cont.h_cache, basis_trunc);
 # above:
 
 m_trunc = truncate(m_cont_raw, basis_trunc)
-m_reduced_trunc = m_trunc([]);
+m_reduced_trunc = m_trunc();
 
 # Finally, let us recompute the magnetization but this time with the truncated
 # quantities and check the heatmap plot:

--- a/examples/multi_ad.jl
+++ b/examples/multi_ad.jl
@@ -84,7 +84,7 @@ terms = map(idx -> to_global(σz, L, first(idx.I)) * to_global(σz, L, last(idx.
 # Correspondingly, the coefficient function now has to map one ``k`` value to a matrix of
 # coefficients of the same size as the `terms` matrix:
 
-coefficient_map = k -> map(idx -> cis(-(first(idx.I) - last(idx.I)) * k) / L,
+coefficients = k -> map(idx -> cis(-(first(idx.I) - last(idx.I)) * k) / L,
                            CartesianIndices((1:L, 1:L)));
 
 # One feature of the structure factor that also shows up in many other affine decompositions
@@ -94,7 +94,7 @@ coefficient_map = k -> map(idx -> cis(-(first(idx.I) - last(idx.I)) * k) / L,
 # decomposition. So let's create the [`AffineDecomposition`](@ref) and compress, exploiting
 # this symmetry using the `symmetric_terms` keyword argument:
 
-SFspin    = AffineDecomposition(terms, coefficient_map)
+SFspin    = AffineDecomposition(terms, coefficients)
 sfspin, _ = compress(SFspin, rbres.basis; symmetric_terms=true);
 
 # In the online evaluation of the structure factor, we then need to define some wavevector

--- a/examples/multi_ad.jl
+++ b/examples/multi_ad.jl
@@ -85,7 +85,7 @@ terms = map(idx -> to_global(σz, L, first(idx.I)) * to_global(σz, L, last(idx.
 # coefficients of the same size as the `terms` matrix:
 
 coefficients = k -> map(idx -> cis(-(first(idx.I) - last(idx.I)) * k) / L,
-                           CartesianIndices((1:L, 1:L)));
+                        CartesianIndices((1:L, 1:L)));
 
 # One feature of the structure factor that also shows up in many other affine decompositions
 # with double-sums is that the term indices commute, i.e. ``O_{r,r'} = O_{r',r}``. In that

--- a/examples/xxz_dmrg.jl
+++ b/examples/xxz_dmrg.jl
@@ -100,7 +100,7 @@ rbres = assemble(H, grid_train, greedy, dm, edcomp);
 # we did for the Hamiltonian. Again, we want to compute the magnetization so that we can
 # reuse the third term of `H`:
 
-M    = AffineDecomposition([H.terms[3]], μ -> [2 / L])
+M    = AffineDecomposition([H.terms[3]], [2 / L])
 m, _ = compress(M, rbres.basis);
 
 # And at that point, we continue as before since we have arrived at the online phase where

--- a/examples/xxz_dmrg.jl
+++ b/examples/xxz_dmrg.jl
@@ -114,7 +114,7 @@ fulldiag = FullDiagonalization(dm);
 # constructing `m` at an arbitary parameter point since its coefficient is
 # parameter-independent:
 
-m_reduced = m([])
+m_reduced = m()
 Δ_online = range(first(Δ), last(Δ); length=100)
 hJ_online = range(first(hJ), last(hJ); length=100)
 grid_online = RegularGrid(Δ_online, hJ_online)

--- a/examples/xxz_ed.jl
+++ b/examples/xxz_ed.jl
@@ -155,7 +155,7 @@ rbres = assemble(H, grid_train, greedy, lobpcg, qrcomp);
 # in the parameter space. Conveniently, the magnetization already is contained in the third
 # term of ``H``:
 
-M    = AffineDecomposition([H.terms[3]], μ -> [2 / L])
+M    = AffineDecomposition([H.terms[3]], [2 / L])
 m, _ = compress(M, rbres.basis);
 
 # Note that the compression again produces an [`AffineDecomposition`](@ref) which now contains

--- a/examples/xxz_ed.jl
+++ b/examples/xxz_ed.jl
@@ -162,10 +162,10 @@ m, _ = compress(M, rbres.basis);
 # only the low-dimensional matrices that operate in reduced basis space. In addition to the
 # compressed observable, [`compress`](@ref) also returns a second decomposition for analysis
 # purposes, which we will not cover in this example and hence did not assign. Since the
-# coefficient ``2L^{-1}`` is actually parameter-independent, we can just construct `m` at
-# some parameter point to obtain the reduced magnetization matrix for all parameters:
+# coefficient ``2L^{-1}`` is actually parameter-independent, we can just construct `m`
+# without passing any parameter point to obtain the constant reduced magnetization matrix:
 
-m_reduced = m([]);
+m_reduced = m();
 
 # ## Online phase
 #

--- a/examples/xxz_pod.jl
+++ b/examples/xxz_pod.jl
@@ -87,7 +87,7 @@ h_cache = HamiltonianCache(H, rbres.basis);
 
 M = AffineDecomposition([H.terms[3]], μ -> [2 / L])
 m, _ = compress(M, rbres.basis)
-m_reduced = m([])
+m_reduced = m()
 Δ_online = range(first(Δ), last(Δ); length=100)
 hJ_online = range(first(hJ), last(hJ); length=100)
 grid_online = RegularGrid(Δ_online, hJ_online)

--- a/examples/xxz_pod.jl
+++ b/examples/xxz_pod.jl
@@ -85,7 +85,7 @@ h_cache = HamiltonianCache(H, rbres.basis);
 # Again, we arrive at the online phase which is performed analogously to
 # [The reduced basis workflow](@ref).
 
-M = AffineDecomposition([H.terms[3]], μ -> [2 / L])
+M = AffineDecomposition([H.terms[3]], [2 / L])
 m, _ = compress(M, rbres.basis)
 m_reduced = m()
 Δ_online = range(first(Δ), last(Δ); length=100)

--- a/src/affine_decomposition.jl
+++ b/src/affine_decomposition.jl
@@ -6,21 +6,24 @@ O(\\bm{\\mu}) = \\sum_{r=1}^R \\alpha_r(\\bm{\\mu})\\, O_r
 ```
 
 where `terms<:AbstractArray` carries the ``O_r`` matrices (or more generally linear maps)
-and the `coefficient_map<:Function` implements the ``\\alpha_r(\\bm{\\mu})`` coefficient
-functions.
+and the `coefficients` implements the ``\\alpha_r(\\bm{\\mu})`` coefficient functions.
+
+In the case where the ``\\alpha_r`` are constant coefficients, i.e. that don't depend on
+the parameter vector, `coefficients` can also just be an `AbstractArray` of the same size
+as `terms`.
 
 Note that ``r = (r_1, \\dots, r_d)`` generally is a multi-index and as such `terms`
-can be a ``d``-dimensional array. Correspondingly, `coefficient_map` maps parameter points
+can be a ``d``-dimensional array. Correspondingly, `coefficients` maps parameter points
 ``\\bm{\\mu}`` to an `size(terms)` array.
 """
-struct AffineDecomposition{T<:AbstractArray,F<:Function}
+struct AffineDecomposition{T<:AbstractArray,F}
     terms::T
-    coefficient_map::F
-    function AffineDecomposition(terms::AbstractArray, coefficient_map::Function)
+    coefficients::F
+    function AffineDecomposition(terms::AbstractArray, coefficients)
         if !all(s -> s == size(terms[1]), size.(terms))
             error("affine terms have different dimensions")
         else
-            new{typeof(terms),typeof(coefficient_map)}(terms, coefficient_map)
+            new{typeof(terms),typeof(coefficients)}(terms, coefficients)
         end
     end
 end
@@ -36,10 +39,16 @@ n_terms(ad::AffineDecomposition) = length(ad.terms)
 # TODO: fix docs here -> use DocStringExtensions
 """
     (ad::AffineDecomposition)(μ)
+    (ad::AffineDecomposition{<:AbstractArray,<:AbstractArray})()
 
-Explicitly evaluate the affine decomposition sum at parameter point `μ`.
+Explicitly evaluate the affine decomposition sum at parameter point `μ` or if no parameter
+dependency exists, construct the constant linear combination.
 """
-(ad::AffineDecomposition)(μ) = sum(ad.coefficient_map(μ) .* ad.terms)
+(ad::AffineDecomposition)(μ) = sum(ad.coefficients(μ) .* ad.terms)
+
+function (ad::AffineDecomposition{<:AbstractArray,<:AbstractArray})()
+    sum(ad.coefficients .* ad.terms)
+end
 
 """
     compress(ad::AffineDecomposition, basis::RBasis)
@@ -50,8 +59,8 @@ corresponding to ``o = B^\\dagger O B``.
 function compress(ad::AffineDecomposition, basis::RBasis)
     matrixel = compress.(ad.terms, Ref(basis.snapshots))  # ⟨ψᵢ|O|ψⱼ⟩
     rbterms = map(m -> basis.vectors' * m * basis.vectors, matrixel)  # transform to RB
-    (; rb=AffineDecomposition(rbterms, ad.coefficient_map),
-     raw=AffineDecomposition(matrixel, ad.coefficient_map))
+    (; rb=AffineDecomposition(rbterms, ad.coefficients),
+     raw=AffineDecomposition(matrixel, ad.coefficients))
 end
 
 """
@@ -82,8 +91,6 @@ function compress(ad::AffineDecomposition{<:Matrix,<:Function},
     matrixel = promote_type.(matrixel)  # Promote to common floating-point type
     rbterms = map(m -> basis.vectors' * m * basis.vectors, matrixel)
 
-    (; rb=AffineDecomposition(rbterms, ad.coefficient_map),
-     raw=AffineDecomposition(matrixel, ad.coefficient_map))
 end
 
 """

--- a/src/affine_decomposition.jl
+++ b/src/affine_decomposition.jl
@@ -90,7 +90,8 @@ function compress(ad::AffineDecomposition{<:Matrix,<:Function},
     end  # Use "symmetry" to set transposed elements
     matrixel = promote_type.(matrixel)  # Promote to common floating-point type
     rbterms = map(m -> basis.vectors' * m * basis.vectors, matrixel)
-
+    (; rb=AffineDecomposition(rbterms, ad.coefficients),
+     raw=AffineDecomposition(matrixel, ad.coefficients))
 end
 
 """

--- a/src/affine_decomposition.jl
+++ b/src/affine_decomposition.jl
@@ -16,9 +16,9 @@ Note that ``r = (r_1, \\dots, r_d)`` generally is a multi-index and as such `ter
 can be a ``d``-dimensional array. Correspondingly, `coefficients` maps parameter points
 ``\\bm{\\mu}`` to an `size(terms)` array.
 """
-struct AffineDecomposition{T<:AbstractArray,F}
+struct AffineDecomposition{T<:AbstractArray,C}
     terms::T
-    coefficients::F
+    coefficients::C
     function AffineDecomposition(terms::AbstractArray, coefficients)
         if !all(s -> s == size(terms[1]), size.(terms))
             error("affine terms have different dimensions")

--- a/src/affine_decomposition.jl
+++ b/src/affine_decomposition.jl
@@ -72,8 +72,7 @@ with two indices (double-sum observables), including an option to
 exploit the possible symmetry of terms ``O_{r,r'} = O_{r',r}``,
 such that only the necessary compressions are computed.
 """
-function compress(ad::AffineDecomposition{<:Matrix,<:Function},
-                  basis::RBasis; symmetric_terms=false)
+function compress(ad::AffineDecomposition{<:Matrix}, basis::RBasis; symmetric_terms=false)
     # TODO: replace symmetric_terms by some generalized Symmetric type in the long run
     is_nonredundant(a, b) = (size(ad.terms, 1) > size(ad.terms, 2)) ? ≥(a, b) : ≤(a, b)
     matrixel = map(CartesianIndices(ad.terms)) do idx

--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -90,11 +90,9 @@ function assemble(info::NamedTuple, H::AffineDecomposition, grid, greedy::Greedy
         # Compute residual on training grid and find maximum for greedy condition
         err_grid = similar(grid, Float64)
         λ_grid   = similar(grid, Vector{Float64})
-        φ_grid   = similar(grid, Matrix{ComplexF64})
         for (idx, μ) in pairs(grid)
             sol = solve(info.h_cache.h, info.basis.metric, μ, solver_online)
             λ_grid[idx] = sol.values
-            φ_grid[idx] = sol.vectors
             err_grid[idx] = estimate_error(greedy.estimator, μ, info.h_cache,
                                            info.basis, sol)
         end
@@ -136,7 +134,7 @@ function assemble(info::NamedTuple, H::AffineDecomposition, grid, greedy::Greedy
         h_cache = HamiltonianCache(info.h_cache, ext.basis)
 
         # Update iteration state info
-        info_new = (; iteration=n, err_grid, λ_grid, φ_grid, err_max, μ=μ_next,
+        info_new = (; iteration=n, err_grid, λ_grid, err_max, μ=μ_next,
                     basis=ext.basis, cache=info.cache, h_cache, extend_info=ext, 
                     state=:iterate)
         info = callback(info_new)

--- a/src/hamiltonian_cache.jl
+++ b/src/hamiltonian_cache.jl
@@ -31,9 +31,9 @@ function HamiltonianCache(H::AffineDecomposition, basis::RBasis)
     ΨHHΨ = reshape([overlap_matrix(v1, v2) for v1 in HΨ for v2 in HΨ],
                    (n_terms(H), n_terms(H)))
     h = AffineDecomposition([basis.vectors' * term * basis.vectors for term in ΨHΨ],
-                            H.coefficient_map)
+                            H.coefficients)
     h² = AffineDecomposition([basis.vectors' * term * basis.vectors for term in ΨHHΨ],
-                             μ -> (H.coefficient_map(μ) * H.coefficient_map(μ)'))
+                             μ -> (H.coefficients(μ) * H.coefficients(μ)'))
     HamiltonianCache(H, HΨ, ΨHΨ, ΨHHΨ, h, h²)
 end
 
@@ -83,8 +83,8 @@ function HamiltonianCache(hc::HamiltonianCache, basis::RBasis{V,T}) where {V,T}
 
     # Transform using basis.vectors and creat AffineDecompositions
     h = AffineDecomposition([basis.vectors' * term * basis.vectors for term in ΨHΨ],
-                            hc.H.coefficient_map)
+                            hc.H.coefficients)
     h² = AffineDecomposition([basis.vectors' * term * basis.vectors for term in ΨHHΨ],
-                             μ -> (hc.H.coefficient_map(μ) * hc.H.coefficient_map(μ)'))
+                             μ -> (hc.H.coefficients(μ) * hc.H.coefficients(μ)'))
     HamiltonianCache(hc.H, HΨ, ΨHΨ, ΨHHΨ, h, h²)
 end

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -87,7 +87,7 @@ Base.size(o::ApproxMPO) = size(o.mpo)
 Compute sum with `ApproxMPO`s using the exact `ITensors` operator sum.
 """
 function (ad::AffineDecomposition{<:AbstractArray{<:ApproxMPO}})(μ)
-    θ = ad.coefficient_map(μ)
+    θ = ad.coefficients(μ)
     opsum = sum(c * term.opsum for (c, term) in zip(θ, ad.terms))
     MPO(opsum, last.(siteinds(ad.terms[1].mpo)))
 end

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -52,11 +52,11 @@ function Base.truncate(hc::HamiltonianCache, basis_trunc::RBasis)
     # Adjust reduced Hamiltonian AffineDecompositions
     h_trunc = AffineDecomposition(
         [basis_trunc.vectors' * term * basis_trunc.vectors for term in ΨHΨ_trunc],
-        hc.H.coefficient_map
+        hc.H.coefficients
     )
     h²_trunc = AffineDecomposition(
         [basis_trunc.vectors' * term * basis_trunc.vectors for term in ΨHHΨ_trunc],
-        μ -> (hc.H.coefficient_map(μ) * hc.H.coefficient_map(μ)')
+        μ -> (hc.H.coefficients(μ) * hc.H.coefficients(μ)')
     )
 
     HamiltonianCache(hc.H, HΨ_trunc, ΨHΨ_trunc, ΨHHΨ_trunc, h_trunc, h²_trunc)
@@ -81,12 +81,12 @@ function Base.truncate(ad_raw::AffineDecomposition, basis_trunc::RBasis)
     idx_trunc = dimension(basis_trunc)
     V = basis_trunc.vectors
     terms_trunc = [V' * term[1:idx_trunc, 1:idx_trunc] * V for term in ad_raw.terms]
-    AffineDecomposition(terms_trunc, ad_raw.coefficient_map)
+    AffineDecomposition(terms_trunc, ad_raw.coefficients)
 end
 
 function Base.truncate(ad::AffineDecomposition,
                        basis_trunc::RBasis{V,T,P,<:UniformScaling}) where {V,T<:Number,P}
     idx_trunc = dimension(basis_trunc)
     AffineDecomposition([term[1:idx_trunc, 1:idx_trunc] for term in ad.terms],
-                        ad.coefficient_map)
+                        ad.coefficients)
 end

--- a/test/affine_decomposition.jl
+++ b/test/affine_decomposition.jl
@@ -21,16 +21,16 @@ using ReducedBasis: AffineDecomposition, n_terms, compress
 
     @testset "Linear indices" begin
         terms = [rand(N, N) for _ in 1:Q]
-        coefficient_map = μ -> rand(Q) .* μ
-        ad = AffineDecomposition(terms, coefficient_map)
+        coefficients = μ -> rand(Q) .* μ
+        ad = AffineDecomposition(terms, coefficients)
         adcomp, adraw = compress(ad, basis)
         ad_test(terms, ad, adcomp, adraw)
     end
 
     @testset "Multi indices" begin
         terms = map(r -> rand(N, N), zeros(Q, Q))
-        coefficient_map = μ -> (μ * μ') * rand(Q, Q)
-        ad = AffineDecomposition(terms, coefficient_map)
+        coefficients = μ -> (μ * μ') * rand(Q, Q)
+        ad = AffineDecomposition(terms, coefficients)
         adcomp, adraw = compress(ad, basis)
         ad_test(terms, ad, adcomp, adraw)
     end
@@ -39,8 +39,8 @@ using ReducedBasis: AffineDecomposition, n_terms, compress
         d₁, d₂ = 3, 5
         @testset "d₁ < d₂" begin
             terms = map(r -> rand(N, N), zeros(d₁, d₂))
-            coefficient_map = μ -> rand(d₁, d₂)
-            ad = AffineDecomposition(terms, coefficient_map)
+            coefficients = μ -> rand(d₁, d₂)
+            ad = AffineDecomposition(terms, coefficients)
             adcomp, adraw = compress(ad, basis; symmetric_terms=true)
             ad_test(terms, ad, adcomp, adraw)
             for idx in findall(x -> x.I[1] > x.I[2], CartesianIndices(terms))
@@ -50,8 +50,8 @@ using ReducedBasis: AffineDecomposition, n_terms, compress
         end
         @testset "d₁ > d₂" begin
             terms = map(r -> rand(N, N), zeros(d₂, d₁))
-            coefficient_map = μ -> rand(d₂, d₁)
-            ad = AffineDecomposition(terms, coefficient_map)
+            coefficients = μ -> rand(d₂, d₁)
+            ad = AffineDecomposition(terms, coefficients)
             adcomp, adraw = compress(ad, basis; symmetric_terms=true)
             ad_test(terms, ad, adcomp, adraw)
             for idx in findall(x -> x.I[1] < x.I[2], CartesianIndices(terms))

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -36,7 +36,7 @@ using ReducedBasis: reconstruct
     sites    = siteinds("S=1/2", L)
     H        = xxz_chain(sites; cutoff=1e-14)  # TODO: if too large -> low residual errors at solved μ do not hold!
     H_matrix = xxz_chain(L)
-    M        = AffineDecomposition([H.terms[3]], μ -> [2 / L])
+    M        = AffineDecomposition([H.terms[3]], [2 / L])
     Δ_off    = range(-1.0, 2.5; length=40)
     hJ_off   = range(0.0, 3.5; length=40)
     grid_off = RegularGrid(Δ_off, hJ_off);

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -12,12 +12,12 @@ using ReducedBasis: reconstruct
             magn_term +=      "Sz", i
         end
         magn_term += "Sz", length(sts)  # Add last magnetization term
-        coefficient_map = μ -> [1.0, μ[1], -μ[2]]
+        coefficients = μ -> [1.0, μ[1], -μ[2]]
         AffineDecomposition(
             [ApproxMPO(MPO(xy_term, sts), xy_term; kwargs...),
             ApproxMPO(MPO(zz_term, sts), zz_term; kwargs...),
             ApproxMPO(MPO(magn_term, sts), magn_term; kwargs...)],
-            coefficient_map)
+            coefficients)
     end
     function xxz_chain(N)
         σx = sparse([0.0 1.0; 1.0 0.0])
@@ -27,8 +27,8 @@ using ReducedBasis: reconstruct
                             to_global(N, σy, i) * to_global(N, σy, i + 1) for i in 1:(N-1)])
         H2 = 0.25 * sum([to_global(N, σz, i) * to_global(N, σz, i + 1) for i in 1:(N-1)])
         H3 = 0.5  * sum([to_global(N, σz, i) for i in 1:N])
-        coefficient_map = μ -> [1.0, μ[1], -μ[2]]
-        AffineDecomposition([H1, H2, H3], coefficient_map)
+        coefficients = μ -> [1.0, μ[1], -μ[2]]
+        AffineDecomposition([H1, H2, H3], coefficients)
     end
 
     # Offline/online parameters
@@ -65,7 +65,7 @@ using ReducedBasis: reconstruct
         @testset "Correct magnetization values" begin
             fd = FullDiagonalization(solver_truth)
             m, _ = compress(M, info.basis)
-            m_reduced = m([1])
+            m_reduced = m()
             magnetization = map(grid_on) do μ
                 _, φ_rb = solve(info.h_cache.h, info.basis.metric, μ, fd)
                 sum(eachcol(φ_rb)) do φ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,9 +25,9 @@ function xxz_chain(N)
                         to_global(N, σy, i) * to_global(N, σy, i + 1) for i in 1:(N-1)])
     H2 = 0.25 * sum([to_global(N, σz, i) * to_global(N, σz, i + 1) for i in 1:(N-1)])
     H3 = 0.5  * sum([to_global(N, σz, i) for i in 1:N])
-    coefficient_map = μ -> [1.0, μ[1], -μ[2]]
+    coefficients = μ -> [1.0, μ[1], -μ[2]]
 
-    AffineDecomposition([H1, H2, H3], coefficient_map)
+    AffineDecomposition([H1, H2, H3], coefficients)
 end
 
 # Convenience function for fast generation of XXZ RBasis

--- a/test/xxz.jl
+++ b/test/xxz.jl
@@ -5,7 +5,7 @@ using ReducedBasis
     # Offline/online parameters
     L        = 6
     H        = xxz_chain(L)
-    M        = AffineDecomposition([H.terms[3]], μ -> [2 / L])
+    M        = AffineDecomposition([H.terms[3]], [2 / L])
     Δ_off    = range(-1.0, 2.5; length=40)
     hJ_off   = range(0.0, 3.5; length=40)
     grid_off = RegularGrid(Δ_off, hJ_off);

--- a/test/xxz.jl
+++ b/test/xxz.jl
@@ -31,7 +31,7 @@ using ReducedBasis
         @testset "Correct magnetization values" begin
             fd = FullDiagonalization(solver_truth)
             m, _ = compress(M, info.basis)
-            m_reduced = m([1])
+            m_reduced = m()
             magnetization = map(grid_on) do μ
                 _, φ_rb = solve(info.h_cache.h, info.basis.metric, μ, fd)
                 sum(eachcol(φ_rb)) do φ


### PR DESCRIPTION
The type restriction on the `coefficient_map` should be lifted in order to represent affine decompositions with constant coefficients. Also, as it turns out, this seems necessary to allow for a working custom serialization of `AffineDecomposition`s.

@mfherbst Do you think we should implement a `compress(::AffineDecomposition{<:AbstractArray,<:AbstractArray}, ...)` for affine decompositions with constant coefficients that returns the compressed matrix (as we shortly discussed with regards to `m_reduced` in the docs examples)?

It could be that this makes things more confusing, since `compress` would then return 3 objects (the matrix, the compressed `AffineDecomposition` and a `AffineDecomposition` with only the matrix elements, which is needed for later truncation).

- closes #40 