### PR TITLE
Implement more general initial guess mechanism

### DIFF
--- a/examples/basis_analysis.jl
+++ b/examples/basis_analysis.jl
@@ -90,7 +90,7 @@ using Statistics
 rbvecs = similar(grid_online, Matrix{ComplexF64})
 magnetization = similar(grid_online, Float64)
 for (idx, μ) in pairs(grid_online)
-    _, φ_rb = solve(rbres.h_cache.h, rbres.basis.metric, μ, fulldiag)
+    _, φ_rb = solve(rbres.h, rbres.basis.metric, μ, fulldiag)
     rbvecs[idx] = φ_rb
     magnetization[idx] = mean(u -> abs(dot(u, m_reduced, u)), eachcol(φ_rb))
 end

--- a/examples/multi_ad.jl
+++ b/examples/multi_ad.jl
@@ -113,7 +113,7 @@ using Statistics
 wavevectors = [0.0, π/4, π/2, π]
 sf = [zeros(size(grid_online)) for _ in 1:length(wavevectors)]
 for (idx, μ) in pairs(grid_online)
-    _, φ_rb = solve(rbres.h_cache.h, rbres.basis.metric, μ, fulldiag)
+    _, φ_rb = solve(rbres.h, rbres.basis.metric, μ, fulldiag)
     for (i, k) in enumerate(wavevectors)
         sf[i][idx] = mean(u -> real(dot(u, sfspin(k), u)), eachcol(φ_rb))
     end

--- a/examples/xxz_dmrg.jl
+++ b/examples/xxz_dmrg.jl
@@ -122,7 +122,7 @@ grid_online = RegularGrid(Δ_online, hJ_online)
 
 using Statistics
 magnetization = map(grid_online) do μ
-    _, φ_rb = solve(rbres.h_cache.h, rbres.basis.metric, μ, fulldiag)
+    _, φ_rb = solve(rbres.h, rbres.basis.metric, μ, fulldiag)
     mean(u -> abs(dot(u, m_reduced, u)), eachcol(φ_rb))
 end;
 

--- a/examples/xxz_ed.jl
+++ b/examples/xxz_ed.jl
@@ -191,7 +191,7 @@ fulldiag = FullDiagonalization(lobpcg);
 
 using Statistics
 magnetization = map(grid_online) do μ
-    _, φ_rb = solve(rbres.h_cache.h, rbres.basis.metric, μ, fulldiag)
+    _, φ_rb = solve(rbres.h, rbres.basis.metric, μ, fulldiag)
     mean(u -> abs(dot(u, m_reduced, u)), eachcol(φ_rb))
 end;
 

--- a/src/ReducedBasis.jl
+++ b/src/ReducedBasis.jl
@@ -36,7 +36,7 @@ export print_callback
 include("callback.jl")
 
 export Greedy, ErrorEstimate, Residual
-export estimate_error, assemble, interpolate, rb_guess
+export estimate_error, assemble, interpolate, rb_guess, random_guess
 include("greedy.jl")
 
 export POD

--- a/src/ReducedBasis.jl
+++ b/src/ReducedBasis.jl
@@ -36,7 +36,7 @@ export print_callback
 include("callback.jl")
 
 export Greedy, ErrorEstimate, Residual
-export estimate_error, assemble, interpolate
+export estimate_error, assemble, interpolate, rb_guess
 include("greedy.jl")
 
 export POD

--- a/src/ReducedBasis.jl
+++ b/src/ReducedBasis.jl
@@ -32,7 +32,7 @@ export default_sweeps
 include("mps.jl")
 
 export InfoCollector
-export print_callback
+export print_callback, mps_callback
 include("callback.jl")
 
 export Greedy, ErrorEstimate, Residual

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -26,30 +26,6 @@ function print_callback(info)
 end
 
 """
-    mps_callback(info)
-    
-Print maximal bond dimension, truncation error and other MPS diagnostics.
-"""
-function mps_callback(info)
-    if info.state == :iterate
-        print("→ ")
-        print("χ_max: ", maxlinkdim.(info.basis.snapshots), "\t")
-        print("⟨H²⟩-⟨H⟩²: ", round.(info.solver_info.variances; sigdigits=3), "\t")
-        print("iterations: ", info.solver_info.iterations, "\t")
-        print("max. truncerr: ", round(info.solver_info.maxtruncerr; sigdigits=3), "\t")
-        if isone(info.iteration)
-            print("m: ", length(info.basis.snapshots), "\t")
-        else
-            print("m: ", info.extend_info.keep, "\t")
-            print("λ_min: ", round(info.extend_info.λ_min; sigdigits=3))
-        end
-        println()  # line break
-        flush(stdout)
-    end
-    info
-end
-
-"""
 Carries a `Dict` of `Vector`s which contain information from greedy assembly iterations.
 """
 struct InfoCollector

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -33,12 +33,12 @@ Print maximal bond dimension, truncation error and other MPS diagnostics.
 function mps_callback(info)
     if info.state == :iterate
         print("→ ")
-        print("χ_max: ", maxlinkdim.(info.solver_info.vectors), "\t")
+        print("χ_max: ", maxlinkdim.(info.basis.snapshots), "\t")
         print("⟨H²⟩-⟨H⟩²: ", round.(info.solver_info.variances; sigdigits=3), "\t")
         print("iterations: ", info.solver_info.iterations, "\t")
         print("max. truncerr: ", round(info.solver_info.maxtruncerr; sigdigits=3), "\t")
         if isone(info.iteration)
-            print("m: ", length(info.solver_info.vectors), "\t")
+            print("m: ", length(info.basis.snapshots), "\t")
         else
             print("m: ", info.extend_info.keep, "\t")
             print("λ_min: ", round(info.extend_info.λ_min; sigdigits=3))
@@ -66,9 +66,10 @@ state object. Possible fields to select from are:
 - `λ_grid`: RB energies on all training grid points.
 - `err_max`: maximal error estimate on the grid.
 - `μ`: parameter point at which truth solve has been performed.
-- `solver_info`: output of the solving method, which includes eigenvalues and vectors.
+- `solver_info`: output of the solving method, which excludes eigenvalues and vectors.
 - `basis`: `RBasis` at the current iteration.
-- `extend_info`: info that is specific to the chosen extension procedure.
+- `extend_info`: info that is specific to the chosen extension procedure, not including
+the extended `RBasis`.
 - `condnum`: condition number of the ``B^\\dagger B``.
 - `h`: current reduced Hamiltonian.
 - `h_cache`: `HamiltonianCache` at the current iteration.

--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -41,7 +41,7 @@ Greedy reduced basis assembling strategy.
     estimator::ErrorEstimate
     tol::Float64      = 1e-3
     n_truth_max::Int  = 64
-    Ψ_init::Function  = rb_guess
+    Ψ_init            = rb_guess
     verbose::Bool     = true
     exit_checks::Bool = true
 end

--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -31,7 +31,7 @@ Greedy reduced basis assembling strategy.
   See also [`estimate_error`](@ref)
 - `tol::Float64=1e-3`: tolerance for error estimate, below which the assembly is terminated.
 - `n_truth_max::Int=64`: maximal number of truth solves to be taken up in the basis.
-- `init_from_rb::Bool=true`: if `true`, uses initial guesses from RB eigenvectors.
+- `Ψ_init::Function=rb_guess`: returns initial guess for truth solver.
   See also [`interpolate`](@ref).
 - `verbose::Bool=true`: print information during assembly if `true`.
 - `exit_checks::Bool=true`: if `false`, no exit checks will be performed and the assembly
@@ -39,24 +39,33 @@ Greedy reduced basis assembling strategy.
 """
 @kwdef struct Greedy
     estimator::ErrorEstimate
-    tol::Float64       = 1e-3
-    n_truth_max::Int   = 64
-    init_from_rb::Bool = true  # TODO: More general mechanism
-    verbose::Bool      = true
-    exit_checks::Bool  = true
+    tol::Float64      = 1e-3
+    n_truth_max::Int  = 64
+    Ψ_init::Function  = rb_guess
+    verbose::Bool     = true
+    exit_checks::Bool = true
 end
 
 """
-    interpolate(basis::RBasis, h::AffineDecomposition, μ, _, solver_online)
+    interpolate(basis::RBasis, h::AffineDecomposition, μ, solver_online)
 
 Compute Hilbert-space-dimensional ground state vector at parameter point `μ`
 from the reduced basis using
 ``\\bm{\\Phi}(\\bm{\\mu}) = B \\bm{\\varphi}(\\bm{\\mu})``.
 """
-function interpolate(basis::RBasis, h::AffineDecomposition, μ, _, solver_online)
+function interpolate(basis::RBasis, h::AffineDecomposition, μ, solver_online)
     # TODO: benchmark for realistic problems
     _, φ_rb = solve(h, basis.metric, μ, solver_online)
     hcat(basis.snapshots...) * basis.vectors * φ_rb
+end
+
+# TODO: add docs
+function rb_guess(info, args)
+    if info.state == :start
+        nothing  # TODO: add random_guess dispatching on type of args.solver_truth or equivalent
+    else
+        interpolate(info.basis, info.h_cache.h, info.μ, args.solver_online)
+    end
 end
 
 """
@@ -106,12 +115,10 @@ function assemble(info::NamedTuple, H::AffineDecomposition, grid, greedy::Greedy
         end
 
         # Construct initial guess at μ_next and run truth solve
-        if greedy.init_from_rb
-            Ψ₀ = interpolate(info.basis, info.h_cache.h, μ_next, solver_truth, solver_online)
-        else
-            Ψ₀ = nothing
-        end
-        truth = solve(H, μ_next, Ψ₀, solver_truth)
+        Ψ_init = greedy.Ψ_init((; info..., err_grid, λ_grid, err_max, μ=μ_next),
+                               (; H, grid, greedy, solver_truth, compressalg,
+                                solver_online))
+        truth = solve(H, μ_next, Ψ_init, solver_truth)
 
         # Append truth vector according to solver method
         ext = extend(info.basis, truth.vectors, μ_next, compressalg)
@@ -151,14 +158,13 @@ end
 
 function assemble(H::AffineDecomposition, grid, greedy::Greedy, solver_truth, compressalg;
                   μ_start=grid[1], callback=print_callback, kwargs...)
-    info = callback((; cache=(;), state=:start))
-    if info.state == :start
-        truth   = solve(H, μ_start, nothing, solver_truth)
-        BᵀB     = overlap_matrix(truth.vectors, truth.vectors)
-        basis   = RBasis(truth.vectors, fill(μ_start, length(truth.vectors)), I, BᵀB, BᵀB)
-        h_cache = HamiltonianCache(H, basis)
-        info    = (; iteration=1, err_max=NaN, μ=μ_start, basis, h_cache,
-                   cache=info.cache, state=:iterate)
-    end
+    info    = callback((; cache=(;), state=:start))
+    Ψ_init  = greedy.Ψ_init(info, (; H, grid, greedy, solver_truth, compressalg, kwargs...))
+    truth   = solve(H, μ_start, Ψ_init, solver_truth)
+    BᵀB     = overlap_matrix(truth.vectors, truth.vectors)
+    basis   = RBasis(truth.vectors, fill(μ_start, length(truth.vectors)), I, BᵀB, BᵀB)
+    h_cache = HamiltonianCache(H, basis)
+    info    = (; iteration=1, err_max=NaN, μ=μ_start, basis, h_cache,
+                cache=info.cache, state=:iterate)
     assemble(info, H, grid, greedy, solver_truth, compressalg; callback, kwargs...)
 end

--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -154,9 +154,10 @@ function assemble(info::NamedTuple, H::AffineDecomposition, grid, greedy::Greedy
         # Update basis with new snapshot/vector/metric and compute reduced terms
         h_cache = HamiltonianCache(info.h_cache, ext.basis)
 
-        # Update iteration state info
+        # Update iteration state info (use Base.structdiff to remove keys from NamedTuple)
         info_new = (; iteration=n, err_grid, λ_grid, err_max, μ=μ_next,
-                    solver_info=truth, basis=ext.basis, extend_info=ext,
+                    solver_info=Base.structdiff(truth, (; values=nothing, vectors=nothing)),
+                    basis=ext.basis, extend_info=Base.structdiff(ext, (; basis=nothing)),
                     condnum=metric_condition, h=h_cache.h, h_cache,
                     cache=info.cache, state=:iterate)
         info = callback(info_new)

--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -59,14 +59,27 @@ function interpolate(basis::RBasis, h::AffineDecomposition, μ, solver_online)
     hcat(basis.snapshots...) * basis.vectors * φ_rb
 end
 
-# TODO: add docs
+"""
+    rb_guess(info, args)
+
+Provide the reduced basis interpolated ground state as an initial guess for
+the truth solver.
+"""
 function rb_guess(info, args)
     if info.state == :start
-        nothing  # TODO: add random_guess dispatching on type of args.solver_truth or equivalent
+        nothing
     else
         interpolate(info.basis, info.h_cache.h, info.μ, args.solver_online)
     end
 end
+
+"""
+    random_guess(info, args)
+
+Provides a random initial guess according to the truth solver method.
+"""
+random_guess(info, args) = nothing
+# TODO: properly implement random_guess interface
 
 """
     assemble(H, grid, greedy, solver_truth, compressalg; <keyword arguments>)

--- a/src/hamiltonian_cache.jl
+++ b/src/hamiltonian_cache.jl
@@ -46,6 +46,10 @@ Hamiltonian applications and inner products.
 function HamiltonianCache(hc::HamiltonianCache, basis::RBasis{V,T}) where {V,T}
     d_basis = dimension(basis)
     m = multiplicity(basis)[end]  # Multiplicity of last truth solve
+    if d_basis == length(hc.HΨ[1])  # In case no new vector was added to basis
+        @warn "basis does not contain a new snapshot"
+        return hc
+    end
 
     # Compute new Hamiltonian application HΨ
     HΨ = copy(hc.HΨ)  # To make function non-mutating

--- a/src/lobpcg.jl
+++ b/src/lobpcg.jl
@@ -64,25 +64,21 @@ function FullDiagonalization(lobpcg::LOBPCG)
 end
 
 """
-    solve(H::AffineDecomposition, μ, Ψ₀::Union{Matrix,Nothing}, lobpcg::LOBPCG)
+    solve(H::AffineDecomposition, μ, Ψ₀::Matrix, lobpcg::LOBPCG)
+    solve(H::AffineDecomposition, μ, ::Nothing, lobpcg::LOBPCG)
 
 Solve using [`LOBPCG`](@ref). If `nothing` is provided as an initial guess,
 an orthogonal random matrix will be used with `lobpcg.n_target + lobpcg.n_ep_extra`
 column vectors.
 """
-function solve(H::AffineDecomposition, μ, Ψ₀::Union{Matrix,Nothing}, lobpcg::LOBPCG)
-    if isnothing(Ψ₀)  # Build initial guess if needed
-        n_states = lobpcg.n_target + lobpcg.n_ep_extra
-        Ψ₀ = Matrix(qr(randn(ComplexF64, size(H, 1), n_states)).Q)
-    else
-        !(size(Ψ₀, 1) == size(H, 1)) && error("Ψ₀ and H dimensions don't match")
-        if size(Ψ₀, 2) < lobpcg.n_target + lobpcg.n_ep_extra
-            Ψ₀_extra = randn(ComplexF64, size(Ψ₀, 1),
-                             lobpcg.n_target + lobpcg.n_ep_extra - size(Ψ₀, 2))
-            Ψ₀_extra .-= Ψ₀ * (Ψ₀' * Ψ₀_extra)  # Project to orthogonal complement
-            Ψ₀_extra = Matrix(qr(Ψ₀_extra).Q)  # Orthonormalize via QR
-            Ψ₀ = hcat(Ψ₀, Ψ₀_extra)
-        end
+function solve(H::AffineDecomposition, μ, Ψ₀::Matrix, lobpcg::LOBPCG)
+    !(size(Ψ₀, 1) == size(H, 1)) && error("Ψ₀ and H dimensions don't match")
+    if size(Ψ₀, 2) < lobpcg.n_target + lobpcg.n_ep_extra
+        Ψ₀_extra = randn(ComplexF64, size(Ψ₀, 1),
+                            lobpcg.n_target + lobpcg.n_ep_extra - size(Ψ₀, 2))
+        Ψ₀_extra .-= Ψ₀ * (Ψ₀' * Ψ₀_extra)  # Project to orthogonal complement
+        Ψ₀_extra = Matrix(qr(Ψ₀_extra).Q)  # Orthonormalize via QR
+        Ψ₀ = hcat(Ψ₀, Ψ₀_extra)
     end
 
     # Assemble Hamiltonian for parameter value μ
@@ -156,4 +152,10 @@ function solve(H::AffineDecomposition, μ, Ψ₀::Union{Matrix,Nothing}, lobpcg:
                 converged=true, iterations=iterations,
                 X=vec, λ=val .- lobpcg.shift)
     end
+end
+
+function solve(H::AffineDecomposition, μ, ::Nothing, lobpcg::LOBPCG)
+    n_states = lobpcg.n_target + lobpcg.n_ep_extra
+    Ψ₀ = Matrix(qr(randn(ComplexF64, size(H, 1), n_states)).Q)
+    solve(H, μ, Ψ₀, lobpcg)
 end

--- a/src/lobpcg.jl
+++ b/src/lobpcg.jl
@@ -75,7 +75,7 @@ function solve(H::AffineDecomposition, μ, Ψ₀::Matrix, lobpcg::LOBPCG)
     !(size(Ψ₀, 1) == size(H, 1)) && error("Ψ₀ and H dimensions don't match")
     if size(Ψ₀, 2) < lobpcg.n_target + lobpcg.n_ep_extra
         Ψ₀_extra = randn(ComplexF64, size(Ψ₀, 1),
-                            lobpcg.n_target + lobpcg.n_ep_extra - size(Ψ₀, 2))
+                         lobpcg.n_target + lobpcg.n_ep_extra - size(Ψ₀, 2))
         Ψ₀_extra .-= Ψ₀ * (Ψ₀' * Ψ₀_extra)  # Project to orthogonal complement
         Ψ₀_extra = Matrix(qr(Ψ₀_extra).Q)  # Orthonormalize via QR
         Ψ₀ = hcat(Ψ₀, Ψ₀_extra)

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -89,7 +89,7 @@ Compute sum with `ApproxMPO`s using the exact `ITensors` operator sum.
 function (ad::AffineDecomposition{<:AbstractArray{<:ApproxMPO}})(μ)
     θ = ad.coefficients(μ)
     opsum = sum(c * term.opsum for (c, term) in zip(θ, ad.terms))
-    MPO(opsum, last.(siteinds(ad.terms[1].mpo)))
+    MPO(opsum, noprime.(first.(siteinds(ad.terms[1].mpo))))
 end
 
 """
@@ -188,9 +188,9 @@ end
 solve(H::AffineDecomposition, μ, Ψ₀::MPS, dm::DMRG) = solve(H, μ, [Ψ₀], dm)
 
 function solve(H::AffineDecomposition, μ, ::Nothing, dm::DMRG)
-    # last.(siteinds(...)) for two physical indices per tensor, last for non-primed index
-    Ψ₀ = fill(randomMPS(last.(siteinds(H.terms[1].mpo));
-              linkdims=dm.sweeps.maxdim[1]), dm.n_states)
+    # noprime(first.(siteinds(...)()) to obtain original sites
+    sites = noprime.(first.(siteinds(H.terms[1].mpo)))
+    Ψ₀ = fill(randomMPS(sites; linkdims=dm.sweeps.maxdim[1]), dm.n_states)
     solve(H, μ, Ψ₀, dm)
 end
 

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -126,13 +126,13 @@ function FullDiagonalization(dm::DMRG)
 end
 
 """
-    default_sweeps(; cutoff_max=1e-9, bonddim_max=1000)
+    default_sweeps(; cutoff_max=1e-9, bonddim_max=1000, iter_max=100)
 
 Return default `ITensors.Sweeps` object for DMRG solves, containing decreasing noise and
 increasing maximal bond dimension ramps.
 """
-function default_sweeps(; cutoff_max=1e-9, bonddim_max=1000)
-    sweeps = Sweeps(100; cutoff=cutoff_max)
+function default_sweeps(; cutoff_max=1e-9, bonddim_max=1000, iter_max=100)
+    sweeps = Sweeps(iter_max; cutoff=cutoff_max)
     setnoise!(sweeps, [10.0^n for n in -1:-2:-10]..., 0.1cutoff_max)
     setmaxdim!(sweeps, [10n for n in 1:2:10]..., bonddim_max)
     sweeps

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -172,8 +172,9 @@ function solve(H::AffineDecomposition, μ, Ψ₀::Union{Vector{MPS},Nothing}, dm
         end
     end
 
-    variances  = [abs(inner(H_full, Ψ, H_full, Ψ) - inner(Ψ', H_full, Ψ)^2) for Ψ in vectors]
-    iterations = length(observer.energies)
+    variances   = [abs(inner(H_full, Ψ, H_full, Ψ) - inner(Ψ', H_full, Ψ)^2) for Ψ in vectors]
+    iterations  = length(observer.energies)
+    maxtruncerr = maximum(observer.truncerrs)
     if dm.verbose
         length(vectors) > 1 &&
             println("Degenerate point μ = $μ found with m = $(length(vectors))")
@@ -182,7 +183,7 @@ function solve(H::AffineDecomposition, μ, Ψ₀::Union{Vector{MPS},Nothing}, dm
         end
     end
 
-    (; values, vectors, variances, iterations)
+    (; values, vectors, variances, iterations, maxtruncerr)
 end
 
 solve(H::AffineDecomposition, μ, Ψ₀::MPS, dm::DMRG) = solve(H, μ, [Ψ₀], dm)

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -221,14 +221,18 @@ Print maximal bond dimension, truncation error and other MPS diagnostics.
 """
 function mps_callback(info)
     if info.state == :iterate
-        m = isone(info.iteration) ? length(info.basis.snapshots) : info.extend_info.keep
         print("→ ")
         print("χ_max: ", maxlinkdim(info.basis.snapshots[end]), "\t")
         print("⟨H²⟩-⟨H⟩²: ", round.(info.solver_info.variances; sigdigits=3), "\t")
         print("iterations: ", info.solver_info.iterations, "\t")
         print("max. truncerr: ", round(info.solver_info.maxtruncerr; sigdigits=3), "\t")
-        print("m: ", m, "\t")
-        !isone(info.iteration) && print("λ_min: ", round(info.extend_info.λ_min; sigdigits=3))
+        if isone(info.iteration)
+            print("m: ", length(info.basis.snapshots), "\t")
+        else
+            print("m: ", info.extend_info.keep, "\t")
+            λ_min = round(minimum(info.extend_info.Λ); sigdigits=3)
+            print("λ_min: ", λ_min)
+        end
         println()  # line break
         flush(stdout)
     end

--- a/src/rbasis.jl
+++ b/src/rbasis.jl
@@ -190,6 +190,7 @@ function extend(basis::RBasis, new_snapshot::AbstractVector, μ, ed::EigenDecomp
 
     # Orthonormalization via eigenvalue decomposition
     Λ, U = eigen(Hermitian(overlaps))  # Hermitian to automatically sort by smallest λ
+    Λ = abs.(Λ)  # Remove zero elements with negative sign
     λ_error_trunc = 0.0
     keep = 1
     if !iszero(ed.cutoff)
@@ -211,7 +212,7 @@ function extend(basis::RBasis, new_snapshot::AbstractVector, μ, ed::EigenDecomp
     end
     snapshots   = append!(copy(basis.snapshots), new_snapshot[1:keep])  # TODO: use ordering of Λ
     parameters  = append!(copy(basis.parameters), fill(μ, keep))
-    vectors_new = U * Diagonal(1 ./ sqrt.(abs.(Λ)))
+    vectors_new = U * Diagonal(1 ./ sqrt.(Λ))
 
     (; basis=RBasis(snapshots, parameters, vectors_new,
                     overlaps, vectors_new' * overlaps * vectors_new),

--- a/src/rbasis.jl
+++ b/src/rbasis.jl
@@ -199,7 +199,7 @@ function extend(basis::RBasis, new_snapshot::AbstractVector, μ, ed::EigenDecomp
         λ_error_trunc = λ²_errors[idx_trunc]
         keep          = idx_trunc - dimension(basis)
         if keep ≤ 0  # Return old basis, if no significant snapshots can be added
-            return (; basis, keep, λ_error_trunc, λ_min=minimum(Λ))
+            return (; basis, keep, Λ, λ_error_trunc)
         end
 
         if keep != length(new_snapshot)  # Truncate/compress
@@ -215,5 +215,5 @@ function extend(basis::RBasis, new_snapshot::AbstractVector, μ, ed::EigenDecomp
 
     (; basis=RBasis(snapshots, parameters, vectors_new,
                     overlaps, vectors_new' * overlaps * vectors_new),
-       keep, λ_error_trunc, λ_min=minimum(Λ))
+     keep, Λ, λ_error_trunc)
 end

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -156,4 +156,36 @@ using ReducedBasis: reconstruct
             test_low_errors(info, greedy, dm_nondeg)
         end
     end
+
+    @testset "MPS callback" begin
+        greedy = Greedy(; estimator=Residual(), tol=1e-3, n_truth_max=64, 
+                        Ψ_init=random_guess, verbose=false)
+        @testset "Greedy assembly: degenerate" begin
+            collector = InfoCollector(:λ_grid)
+            info = assemble(H, grid_off, greedy, dm_deg, edcomp;
+                            callback=collector ∘ mps_callback)
+            @test multiplicity(info.basis)[1] > 1
+            test_variational(collector)
+            test_L6_magn_plateaus(info, dm_deg)
+            test_low_errors(info, greedy, dm_deg)
+        end
+        @testset "Greedy assembly: non-degenerate" begin
+            info = assemble(H, grid_off, greedy, dm_nondeg, edcomp;
+                            callback=mps_callback ∘ print_callback)
+            test_L6_magn_plateaus(info, dm_nondeg)
+            test_low_errors(info, greedy, dm_nondeg)
+        end
+    end
+end
+
+@testset "Reconstruct" begin
+    sites = siteinds("S=1", 6)
+    rmps  = randomMPS(sites, 4)
+    vec   = ReducedBasis.reconstruct(rmps)
+    @test length(vec) == 3^6
+
+    qnsites = siteinds("S=1/2", 6; conserve_sz=true)
+    qnmps   = MPS(qnsites, ["Up", "Dn", "Dn", "Up", "Up", "Up"])
+    qnvec   = ReducedBasis.reconstruct(qnmps)
+    @test length(qnvec) == 2^6
 end

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -119,7 +119,7 @@ using ReducedBasis: reconstruct
     
     @testset "Initial guess from RB eigenvector" begin
         greedy = Greedy(; estimator=Residual(), tol=1e-3, n_truth_max=64, 
-                        init_from_rb=true, verbose=false)
+                        Ψ_init=rb_guess, verbose=false)
         @testset "Greedy assembly: degenerate" begin
             collector = InfoCollector(:λ_grid)
             info = assemble(H, grid_off, greedy, dm_deg, edcomp; callback=collector)
@@ -139,7 +139,7 @@ using ReducedBasis: reconstruct
 
     @testset "Random initial guess" begin
         greedy = Greedy(; estimator=Residual(), tol=1e-3, n_truth_max=64, 
-                        init_from_rb=false, verbose=false)
+                        Ψ_init=random_guess, verbose=false)
         @testset "Greedy assembly: degenerate" begin
             collector = InfoCollector(:λ_grid)
             info = assemble(H, grid_off, greedy, dm_deg, edcomp; callback=collector)

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -7,8 +7,7 @@ using ReducedBasis
     H        = xxz_chain(L)
     M        = AffineDecomposition([H.terms[3]], μ -> [2 / L])
     grid_off = RegularGrid(range(-1.0, 2.5; length=40), range(0.0, 3.5; length=40))
-    greedy   = Greedy(; estimator=Residual(), tol=1e-3, n_truth_max=32,
-                    init_from_rb=true, verbose=false)
+    greedy   = Greedy(; estimator=Residual(), tol=1e-3, n_truth_max=32, verbose=false)
     lobpcg   = LOBPCG(; n_target=1, tol_degeneracy=1e-4, tol=1e-9)
     n_trunc = 4
     

--- a/test/xxz.jl
+++ b/test/xxz.jl
@@ -13,8 +13,7 @@ using ReducedBasis
     hJ_on    = range(first(hJ_off), last(hJ_off); length=100)
     grid_on  = RegularGrid(Δ_on, hJ_on)
 
-    greedy = Greedy(; estimator=Residual(), tol=1e-3, n_truth_max=32,
-                    init_from_rb=true, verbose=false)
+    greedy = Greedy(; estimator=Residual(), tol=1e-3, n_truth_max=32, verbose=false)
     qrcomp = QRCompress(; tol=1e-10)
     pod    = POD(; n_vectors=32, verbose=false)
 


### PR DESCRIPTION
Enable implementation of an initial guess function in `Greedy`. It dispatches on the `info` tuple and on the arguments that were passed to the `assemble` call. This is important e.g. when using quantum number conserving DMRG, where specific initial states (states with defined QNs) are necessary. On this occasion, the `info` tuple will also be improved.

- closes #31 
- closes #38 