### PR TITLE
Reduce memory consumption of `compress`

### DIFF
--- a/examples/multi_ad.jl
+++ b/examples/multi_ad.jl
@@ -78,14 +78,14 @@ rbres = assemble(H, grid_train, greedy, lobpcg, qrcomp);
 # ``k``-dependency in the coefficients. The double-sum can be encoded by putting all
 # ``S^z_r S^z_{r'}`` combinations into a ``L \times L`` matrix:
 
-terms = map(idx -> to_global(σz, L, first(idx.I)) * to_global(σz, L, last(idx.I)),
-            CartesianIndices((1:L, 1:L)));
+terms = map(idx -> to_global(σz, L, idx[1]) * to_global(σz, L, idx[2]),
+            Iterators.product(1:L, 1:L));
 
 # Correspondingly, the coefficient function now has to map one ``k`` value to a matrix of
 # coefficients of the same size as the `terms` matrix:
 
-coefficients = k -> map(idx -> cis(-(first(idx.I) - last(idx.I)) * k) / L,
-                        CartesianIndices((1:L, 1:L)));
+coefficients = k -> map(idx -> cis(-(idx[1] - idx[2]) * k) / L,
+                        Iterators.product(1:L, 1:L));
 
 # One feature of the structure factor that also shows up in many other affine decompositions
 # with double-sums is that the term indices commute, i.e. ``O_{r,r'} = O_{r',r}``. In that

--- a/src/affine_decomposition.jl
+++ b/src/affine_decomposition.jl
@@ -76,13 +76,13 @@ function compress(ad::AffineDecomposition{<:Matrix}, basis::RBasis; symmetric_te
     # TODO: replace symmetric_terms by some generalized Symmetric type in the long run
     is_nonredundant(a, b) = (size(ad.terms, 1) > size(ad.terms, 2)) ? ≥(a, b) : ≤(a, b)
     matrixel = map(CartesianIndices(ad.terms)) do idx
-        if is_nonredundant(first(idx.I), last(idx.I))  # Upper/lower triangle
+        if is_nonredundant(idx[1], idx[2])  # Upper/lower triangle
             return compress(ad.terms[idx], basis.snapshots)
         end
     end
     for idx in findall(isnothing, matrixel)
         if symmetric_terms
-            matrixel[idx] = matrixel[last(idx.I), first(idx.I)]
+            matrixel[idx] = matrixel[idx[2], idx[1]]
         else
             matrixel[idx] = compress(ad.terms[idx], basis.snapshots)
         end
@@ -99,7 +99,14 @@ end
 Compress one term of an [`AffineDecomposition`](@ref) `ApproxMPO` type.
 """
 function compress(op, snapshots::AbstractVector)
-    overlap_matrix(snapshots, map(Ψ -> op * Ψ, snapshots))
+    overlap_matrix(Ψ -> op * Ψ, snapshots, snapshots)
+    # M = length(snapshots)
+    # matrixel = Matrix{Number}(undef, M, M)
+    # for j in 1:M, i in 1:M
+    #     applied = op * snapshots[j]
+    #     matrixel[i, j] = dot(snapshots[i], applied)
+    # end
+    # promote_type.(matrixel)
 end
 
 """

--- a/test/affine_decomposition.jl
+++ b/test/affine_decomposition.jl
@@ -43,7 +43,7 @@ using ReducedBasis: AffineDecomposition, n_terms, compress
             ad = AffineDecomposition(terms, coefficients)
             adcomp, adraw = compress(ad, basis; symmetric_terms=true)
             ad_test(terms, ad, adcomp, adraw)
-            for idx in findall(x -> x.I[1] > x.I[2], CartesianIndices(terms))
+            for idx in findall(x -> x[1] > x[2], CartesianIndices(terms))
                 @test adcomp.terms[idx] == adcomp.terms[last(idx.I), first(idx.I)]
                 @test adraw.terms[idx]  == adraw.terms[last(idx.I), first(idx.I)]
             end  # Test equivalence of transposed compressed elements
@@ -54,7 +54,7 @@ using ReducedBasis: AffineDecomposition, n_terms, compress
             ad = AffineDecomposition(terms, coefficients)
             adcomp, adraw = compress(ad, basis; symmetric_terms=true)
             ad_test(terms, ad, adcomp, adraw)
-            for idx in findall(x -> x.I[1] < x.I[2], CartesianIndices(terms))
+            for idx in findall(x -> x[1] < x[2], CartesianIndices(terms))
                 @test adcomp.terms[idx] == adcomp.terms[last(idx.I), first(idx.I)]
                 @test adraw.terms[idx]  == adraw.terms[last(idx.I), first(idx.I)]
             end  # Test equivalence of transposed compressed elements

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -180,7 +180,7 @@ end
 
 @testset "Reconstruct" begin
     sites = siteinds("S=1", 6)
-    rmps  = randomMPS(sites, 4)
+    rmps  = randomMPS(sites; linkdims=4)
     vec   = ReducedBasis.reconstruct(rmps)
     @test length(vec) == 3^6
 


### PR DESCRIPTION
Compressions of `AffineDecomposition`s can suffer from sudden increases of memory usage since all observables (i.e. MPOs) are applied simultaneously. To fix this, the observables are applied one-by-one. To that end, `overlap_matrix` now has a method which takes a function as the first argument, which is applied to the second provided vector.

- closes #45