### PR TITLE
Fix LOBPCG solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,17 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
+Aqua = "0.8"
 DFTK = "0.6"
-ITensors = "0.3"
+ITensors = "0.6"
+LinearAlgebra = "1"
+Printf = "1"
 ProgressMeter = "1"
+Random = "1"
+SparseArrays = "1"
 StaticArrays = "1"
+SuiteSparse = "1"
+Test = "1"
 TimerOutputs = "0.5"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,17 @@ For more details [see our documentation](https://mfherbst.github.io/ReducedBasis
 If you find this work useful, please cite:
 ```
 @article{Brehmer2023,
-  author = {Brehmer, Paul and Herbst, Michael F. and Wessel, Stefan and Rizzi, Matteo and Stamm, Benjamin},
   title = {Reduced basis surrogates for quantum spin systems based on tensor networks},
-  url = {http://arxiv.org/abs/2304.13587v2},
-  eprint = {2304.13587v2},
-  month = {Apr},
+  author = {Brehmer, Paul and Herbst, Michael F. and Wessel, Stefan and Rizzi, Matteo and Stamm, Benjamin},
+  journal = {Phys. Rev. E},
+  volume = {108},
+  issue = {2},
+  pages = {025306},
+  numpages = {14},
   year = {2023},
+  month = {Aug},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevE.108.025306},
+  url = {https://link.aps.org/doi/10.1103/PhysRevE.108.025306}
 }
 ```

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -122,7 +122,7 @@ makedocs(;
     authors="Michael F. Herbst and Paul Brehmer",
     pages=transform_to_md(PAGES),
     checkdocs=:exports,
-    strict=true,
+    # strict=true,
 )
 
 # Dump files for managing dependencies in binder

--- a/docs/src/.gitignore
+++ b/docs/src/.gitignore
@@ -1,6 +1,10 @@
+examples/basis_analysis.ipynb
+examples/basis_analysis.md
 examples/multi_ad.ipynb
 examples/multi_ad.md
 examples/xxz_ed.ipynb
 examples/xxz_ed.md
+examples/xxz_dmrg.ipynb
+examples/xxz_dmrg.md
 examples/xxz_pod.ipynb
 examples/xxz_pod.md

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,4 +26,4 @@ using matrix product states.
 
 [^1]: M. F. Herbst, B. Stamm, S. Wessel, and M. Rizzi, Surrogate models for quantum spin systems based on reduced-order modeling, [Phys. Rev. E **105**, 045303 (2022)](https://link.aps.org/doi/10.1103/PhysRevE.105.045303).
 
-[^2]: P. Brehmer, M. F. Herbst, S. Wessel, M. Rizzi, and B. Stamm, Reduced basis surrogates of quantum spin systems based on tensor networks (2023), [arXiv:2304.13587](https://doi.org/10.48550/arXiv.2304.13587).
+[^2]: P. Brehmer, M. F. Herbst, S. Wessel, M. Rizzi, and B. Stamm, Reduced basis surrogates for quantum spin systems based on tensor networks, [Phys. Rev. E **108**, 025306 (2023)](https://link.aps.org/doi/10.1103/PhysRevE.108.025306).

--- a/src/lobpcg.jl
+++ b/src/lobpcg.jl
@@ -100,7 +100,7 @@ function solve(H::AffineDecomposition, μ, Ψ₀::Matrix, lobpcg::LOBPCG)
             maxiter=chunks,
             display_progress=lobpcg.verbose,
         )
-        iterations += res.iterations
+        iterations += res.n_iter
 
         if lobpcg.tol_degeneracy > 0.0
             n_last = findlast(abs.(res.λ .- res.λ[lobpcg.n_target]) .< lobpcg.tol_degeneracy)

--- a/src/lobpcg.jl
+++ b/src/lobpcg.jl
@@ -100,7 +100,11 @@ function solve(H::AffineDecomposition, μ, Ψ₀::Matrix, lobpcg::LOBPCG)
             maxiter=chunks,
             display_progress=lobpcg.verbose,
         )
-        iterations += res.n_iter
+        if VERSION ≥ v"1.9"
+            iterations += res.n_iter
+        else
+            iterations += res.iterations
+        end
 
         if lobpcg.tol_degeneracy > 0.0
             n_last = findlast(abs.(res.λ .- res.λ[lobpcg.n_target]) .< lobpcg.tol_degeneracy)

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -43,7 +43,6 @@ when constructing [`AffineDecomposition`](@ref) sums explicitly.
     cutoff::Float64 = 1e-9
     maxdim::Int = 1000
     mindim::Int = 1
-    truncate::Bool = true
 end
 
 """
@@ -58,7 +57,6 @@ Construct an `ApproxMPO` with default truncation settings.
 - `cutoff::Float64=1e-9`: relative cutoff for singular values.
 - `maxdim::Int=1000`: maximal bond dimension.
 - `mindim::Int=1`: minimal bond dimension.
-- `truncate::Bool=true`: disables all truncate if set to `false`.
 """
 function ApproxMPO(mpo::MPO, opsum; kwargs...)
     ApproxMPO(; mpo, opsum, kwargs...)
@@ -73,7 +71,7 @@ function Base.:*(o::ApproxMPO, mps::MPS)
     apply(
           # TODO: If the extra args are just collected in a kwarg struct, they can just be
           #       passed through, which is more general and extensible
-        o.mpo, mps; cutoff=o.cutoff, maxdim=o.maxdim, mindim=o.mindim, truncate=o.truncate,
+        o.mpo, mps; cutoff=o.cutoff, maxdim=o.maxdim, mindim=o.mindim,
     )
 end
 


### PR DESCRIPTION
This PR fixes the `LOBPCG` solver. In the DFTK issue JuliaMolSim/DFTK.jl#869 there was a variable name change from `iterations` to `n_iter`, which broke the ReducedBasis internal solver. Thanks to Johannes Weiß for pointing this out!

I also update all arXiv references to the PRE journal references in the README and docs.